### PR TITLE
fixed loop for old C versions

### DIFF
--- a/src/kstring.h
+++ b/src/kstring.h
@@ -2,96 +2,104 @@
 #include <stdio.h>
 
 typedef struct {
-    char* data;
-    long long int len;
-}kstring;
-
+	char* data;
+	long long int len;
+} kstring;
 
 long long int string_len(char* s){
-    long long int res = 0;
-    while(*s != '\0'){
-        res++;
-        s++;
-    }
-    return res;
+	long long int res = 0;
+	while(*s != '\0'){
+		res++;
+		s++;
+	}
+	return res;
 }
 
 kstring* create_string(char* str){
-    kstring* pnt = malloc(sizeof(kstring));
-    
-    pnt->data = malloc(sizeof(char) * string_len(str));
-    pnt->len = string_len(str);
-    
-    for(int i = 0; i < string_len(str);i++)
-        pnt->data[i] = str[i];
-    
-    return pnt;
+	kstring* pnt = malloc(sizeof(kstring));
+
+	pnt->data = malloc(sizeof(char) * string_len(str));
+	pnt->len = string_len(str);
+
+	int i;
+
+	for(i = 0; i < string_len(str);i++)
+		pnt->data[i] = str[i];
+
+	return pnt;
 }
 
 void delete_string(kstring* str){
-    free(str->data);
-    free(str);
+	free(str->data);
+	free(str);
 }
 
 void append(kstring* str, char ch){
-    char* result = malloc(sizeof(char) * (str->len + 1));
-    
-    for(long long int i = 0; i < str->len; i++){
-        result[i] = str->data[i];
-    } 
-    
-    result[str->len] = ch;
-    str->len++;
-    free(str->data);
-    str->data = result;
+	char* result = malloc(sizeof(char) * (str->len + 1));
+
+	long long int i;
+
+	for(i = 0; i < str->len; i++){
+		result[i] = str->data[i];
+	}
+
+	result[str->len] = ch;
+	str->len++;
+	free(str->data);
+	str->data = result;
 }
 
 void replace(kstring* str, char a, char b){
-    for(long long int i = 0; i < str->len; i++){
-        if(str->data[i] == a){
-            str->data[i] = b;
-            return;
-        }
-    }
+	long long int i;
+	for(i = 0; i < str->len; i++){
+		if(str->data[i] == a){
+			str->data[i] = b;
+			return;
+		}
+	}
 }
 
 void replace_all(kstring* str, char a, char b){
-    for(long long int i = 0; i < str->len; i++){
-        if(str->data[i] == a)
-            str->data[i] = b;
-    }
+	long long int i;
+	for(i = 0; i < str->len; i++){
+		if(str->data[i] == a)
+		str->data[i] = b;
+	}
 }
 
 
 void strprint(kstring* string){
-    printf(string->data);
+	printf(string->data);
 }
 
 int contains(kstring* string, char ch){
-    for(long long int i = 0; i < string->len; i++){
-        if(string->data[i] == ch)
-            return 1;
-    }
-    return 0;
+	long long int i;
+	for(i = 0; i < string->len; i++){
+		if(string->data[i] == ch)
+			return 1;
+	}
+	return 0;
 }
 
 int contain_str(kstring* string, char* a){
-    int contain;
-    long long int copy;
-    for(long long int i = 0; i < string->len;i++){
-        copy = i;
-        for(long long int j = 0; j < string_len(a);j++){
-            if(string->data[copy] == a[j])
-                contain = 1;
-            else {
-                contain = 0;
-                break;
-            }
-            copy++;
-        }
-        if(contain){
-            return 1;
-        }
-    }
-    return 0;
+	int contain;
+	long long int copy;
+	long long int i;
+	long long int j;
+	for(i = 0; i < string->len;i++){
+		copy = i;
+		for(j = 0; j < string_len(a);j++){
+			if(string->data[copy] == a[j])
+				contain = 1;
+			else {
+				contain = 0;
+				break;
+			}
+			copy++;
+		}
+		if(contain){
+			return 1;
+		}
+	}
+	return 0;
 }


### PR DESCRIPTION
# Fixed loops (for)
Fixed loops (for) for old C versions =)
You can see commit, also what I did with your code! 

```C
#include "src/kstring.h"

int main() {
    kstring *hello = create_string("Hello world");
    strprint(hello);
    return 0;
}
// This code will throw error! Like this!!
/**************
In file included from main.c:1:0:
src/kstring.h: In function 'create_string':
src/kstring.h:24:2: error: 'for' loop initial declarations are only allowed in C99 mode
src/kstring.h:24:2: note: use option -std=c99 or -std=gnu99 to compile your code
src/kstring.h: In function 'append':
src/kstring.h:38:2: error: 'for' loop initial declarations are only allowed in C99 mode
src/kstring.h: In function 'replace':
src/kstring.h:49:2: error: 'for' loop initial declarations are only allowed in C99 mode
src/kstring.h: In function 'replace_all':
src/kstring.h:58:2: error: 'for' loop initial declarations are only allowed in C99 mode
src/kstring.h: In function 'contains':
src/kstring.h:70:2: error: 'for' loop initial declarations are only allowed in C99 mode
src/kstring.h: In function 'contain_str':
src/kstring.h:80:2: error: 'for' loop initial declarations are only allowed in C99 mode
src/kstring.h:82:3: error: 'for' loop initial declarations are only allowed in C99 mode
**************/
```